### PR TITLE
Add security standards and fill broken link scaffolds

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@
 - [Using GitHub Projects](/standards/project-setup.md) to track progress.
 - [Readme Guidelines](/standards/readme-guidelines.md) for project documentation.
 
+#### Accessibility
+
+- [Accessibility Best Practices](/best-practices/accessibility.md) — Lighthouse audits, semantic HTML, keyboard navigation, color contrast, and more.
+
 #### Code Formatting
   CSS
   - [Class Naming with BEM](/standards/css-naming-bestPractice.md) at BizzNEST

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@
 - [Code Review](/standards/code-reviews.md#process) process at BizzNEST:
 - [Bug Reporting](/standards/bug-reporting.md)
 
+#### Security
+
+- [Security Standards](/security/README.md)
+- [Secure Development](/security/secure-development.md)
+- [Data Protection](/security/data-protection.md)
+- [AI Usage Policy](/security/ai-usage-policy.md)
+- [Secrets Management](/security/secrets-management.md)
+- [Incident Response](/security/incident-response.md)
+
 #### Machine Setup
 
 ##### Mac: Install

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -6,3 +6,4 @@
 - [Local and WP Engine Deployment](local-and-wpe-deployment-best-practices.md)
 - [Adding Users to WordPress Dashboard](adding-users-phpadmin-wpdashboard.md)
 - [SFTP into WP Engine Environment](wpe-sftp.md)
+- [Accessibility Best Practices](accessibility.md)

--- a/best-practices/accessibility.md
+++ b/best-practices/accessibility.md
@@ -1,0 +1,201 @@
+# Accessibility Best Practices
+
+Accessibility (often shortened to **a11y**) means building websites and apps that everyone can use — including people who rely on screen readers, keyboard navigation, or other assistive technologies. Accessibility is not optional. It's a core part of building quality software.
+
+---
+
+## Why Accessibility Matters
+
+- **It's the right thing to do.** Everyone deserves equal access to the web.
+- **It's the law.** Many organizations are required to meet accessibility standards (ADA, Section 508, WCAG).
+- **It improves the experience for everyone.** Good accessibility practices lead to cleaner HTML, better SEO, and a better experience for all users — not just those with disabilities.
+
+---
+
+## Fundamental Best Practices
+
+### Use Semantic HTML
+
+Semantic elements tell the browser (and assistive technologies) what your content means, not just how it looks.
+
+> **DO**: Use `<button>` for clickable actions and `<a>` for navigation links.
+>
+> **DON'T**: Use `<div>` or `<span>` with click handlers to fake a button.
+
+> **DO**: Use heading elements (`<h1>` through `<h6>`) in order to create a logical document outline.
+>
+> **DON'T**: Skip heading levels (e.g., jumping from `<h1>` to `<h4>`) or use headings just for styling.
+
+> **DO**: Use `<nav>`, `<main>`, `<header>`, `<footer>`, and `<section>` to define page regions.
+>
+> **DON'T**: Build your entire layout out of `<div>` elements with no semantic meaning.
+
+```html
+<!-- BAD -->
+<div class="button" onclick="submit()">Submit</div>
+
+<!-- GOOD -->
+<button type="submit">Submit</button>
+```
+
+### Provide Alt Text for Images
+
+Screen readers read the `alt` attribute to describe images to users who can't see them.
+
+> **DO**: Write alt text that describes what the image communicates, not what it looks like.
+>
+> **DON'T**: Leave the `alt` attribute empty on images that convey information.
+
+> **DO**: Use an empty `alt=""` for purely decorative images (icons, backgrounds).
+>
+> **DON'T**: Write "image of" or "picture of" in alt text — the screen reader already announces it as an image.
+
+```html
+<!-- BAD — missing alt -->
+<img src="team-photo.jpg">
+
+<!-- BAD — unhelpful alt -->
+<img src="team-photo.jpg" alt="image">
+
+<!-- GOOD -->
+<img src="team-photo.jpg" alt="BizzNEST team members at the 2025 summer hackathon">
+
+<!-- GOOD — decorative image -->
+<img src="decorative-line.svg" alt="">
+```
+
+### Keyboard Navigation
+
+Many users navigate entirely with a keyboard. Every interactive element must be reachable and usable without a mouse.
+
+> **DO**: Make sure all buttons, links, and form fields are reachable with the `Tab` key.
+>
+> **DON'T**: Remove the default focus outline (`outline: none`) without providing a visible alternative.
+
+> **DO**: Use `tabindex="0"` if you need a non-interactive element to be focusable.
+>
+> **DON'T**: Use positive `tabindex` values (e.g., `tabindex="5"`) — they create confusing tab order.
+
+> **DO**: Test your pages by putting your mouse away and navigating only with `Tab`, `Shift+Tab`, `Enter`, and `Space`.
+
+### Color and Contrast
+
+Not everyone sees colors the same way. Don't rely on color alone to communicate meaning.
+
+> **DO**: Maintain a contrast ratio of at least **4.5:1** for normal text and **3:1** for large text (WCAG AA).
+>
+> **DON'T**: Use light gray text on a white background.
+
+> **DO**: Use color **plus** another indicator (icon, underline, text label) to convey information.
+>
+> **DON'T**: Use only red/green to indicate success/failure — colorblind users may not distinguish them.
+
+### Form Accessibility
+
+Forms are where users interact most, and where accessibility mistakes cause the most frustration.
+
+> **DO**: Associate every input with a `<label>` using the `for` attribute.
+>
+> **DON'T**: Use placeholder text as a substitute for labels — it disappears when the user starts typing.
+
+> **DO**: Group related fields with `<fieldset>` and `<legend>`.
+>
+> **DON'T**: Leave form errors vague — tell the user exactly which field has a problem and how to fix it.
+
+```html
+<!-- BAD — no label -->
+<input type="email" placeholder="Email">
+
+<!-- GOOD -->
+<label for="email">Email</label>
+<input type="email" id="email" name="email">
+```
+
+### ARIA (When Necessary)
+
+ARIA (Accessible Rich Internet Applications) attributes add accessibility information to elements that don't have it natively. Use them sparingly.
+
+> **DO**: Use ARIA only when native HTML can't achieve the same result.
+>
+> **DON'T**: Add ARIA attributes to elements that already have built-in accessibility (e.g., don't add `role="button"` to a `<button>`).
+
+> **DO**: Use `aria-label` to provide accessible names for elements that have no visible text.
+>
+> **DON'T**: Use `aria-label` on elements that already have visible text — it overrides the visible text for screen readers.
+
+```html
+<!-- GOOD — icon-only button needs an aria-label -->
+<button aria-label="Close menu">
+  <svg><!-- X icon --></svg>
+</button>
+```
+
+---
+
+## Using Lighthouse for Accessibility Audits
+
+Lighthouse is built into Google Chrome DevTools and scores your page's accessibility from 0 to 100. Run it on every page you build.
+
+### How to Run a Lighthouse Audit
+
+1. Open your page in **Google Chrome**.
+2. Open DevTools (`Cmd + Option + I` on Mac, `Ctrl + Shift + I` on Windows).
+3. Click the **Lighthouse** tab.
+4. Under **Categories**, check **Accessibility** (you can uncheck the others for a faster run).
+5. Choose **Navigation** mode and your device type (Mobile or Desktop).
+6. Click **Analyze page load**.
+
+### Understanding the Results
+
+- **Score 90–100**: Good. Minor improvements may be suggested.
+- **Score 70–89**: Needs work. Review each failing audit and fix them.
+- **Score below 70**: Significant issues. Prioritize fixing these before shipping.
+
+Each issue includes:
+- **What's wrong** — a description of the problem.
+- **Why it matters** — how it affects users with disabilities.
+- **How to fix it** — specific guidance and links to documentation.
+
+### Common Lighthouse Accessibility Failures
+
+| Issue | What It Means | How to Fix |
+|---|---|---|
+| Image elements do not have `[alt]` attributes | Screen readers can't describe the image | Add descriptive `alt` text |
+| Form elements do not have associated labels | Screen readers can't identify the field | Add `<label>` with matching `for` attribute |
+| Background and foreground colors do not have sufficient contrast ratio | Text is hard to read for low-vision users | Increase contrast to meet WCAG AA (4.5:1) |
+| Links do not have a discernible name | Screen readers say "link" with no context | Add visible text or `aria-label` to links |
+| Heading elements are not in a sequentially-descending order | Document outline is confusing for screen reader users | Fix heading levels to follow logical order |
+| `[id]` attributes on active, focusable elements are not unique | Assistive tech may target the wrong element | Ensure all `id` values are unique |
+
+### Tips for Using Lighthouse Effectively
+
+- **Run it early and often.** Don't wait until the project is done — audit each page as you build it.
+- **Test on both Mobile and Desktop.** Accessibility issues can differ between viewport sizes.
+- **Lighthouse doesn't catch everything.** A score of 100 does not mean your site is fully accessible. Manual testing (keyboard navigation, screen reader testing) is still necessary.
+- **Use it alongside other tools.** Try the [axe DevTools extension](https://www.deque.com/axe/devtools/) for more detailed audits.
+
+---
+
+## Accessibility Checklist
+
+Use this checklist before submitting a PR:
+
+- [ ] All images have meaningful `alt` text (or `alt=""` for decorative images)
+- [ ] All form inputs have associated `<label>` elements
+- [ ] Page has a logical heading hierarchy (`h1` → `h2` → `h3`, no skipped levels)
+- [ ] All interactive elements are reachable and usable with keyboard only
+- [ ] Color contrast meets WCAG AA standards (4.5:1 for normal text)
+- [ ] Color is not the only way information is communicated
+- [ ] Focus styles are visible on all interactive elements
+- [ ] Page uses semantic HTML (`<nav>`, `<main>`, `<button>`, etc.)
+- [ ] Lighthouse accessibility score is 90 or above
+- [ ] Manually tested keyboard navigation (Tab through the full page)
+
+---
+
+## Resources
+
+- [WCAG 2.1 Quick Reference](https://www.w3.org/WAI/WCAG21/quickref/) — the official guidelines
+- [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) — check your color contrast ratios
+- [axe DevTools](https://www.deque.com/axe/devtools/) — browser extension for detailed accessibility audits
+- [The A11Y Project](https://www.a11yproject.com/) — community-driven accessibility resource

--- a/security/README.md
+++ b/security/README.md
@@ -9,3 +9,5 @@ These guides cover how we keep our code, data, and systems safe at BizzNEST. Eve
 - [AI Usage Policy](ai-usage-policy.md)
 - [Secrets Management](secrets-management.md)
 - [Incident Response](incident-response.md)
+- [Incident Report Template](incident-report-template.md)
+- [Incident Report Example](incident-report-example.md)

--- a/security/README.md
+++ b/security/README.md
@@ -1,0 +1,11 @@
+# BizzNEST Security Standards
+
+These guides cover how we keep our code, data, and systems safe at BizzNEST. Every team member is responsible for following these practices — security is not optional.
+
+## Table of Contents
+
+- [Secure Development Practices](secure-development.md)
+- [Data Protection](data-protection.md)
+- [AI Usage Policy](ai-usage-policy.md)
+- [Secrets Management](secrets-management.md)
+- [Incident Response](incident-response.md)

--- a/security/ai-usage-policy.md
+++ b/security/ai-usage-policy.md
@@ -1,0 +1,107 @@
+# AI Usage Policy at BizzNEST
+
+AI tools can help you write code faster, debug problems, and learn new concepts. But they also come with real risks — especially around data privacy and security. Follow these rules to use AI responsibly.
+
+---
+
+## Approved Tools
+
+Refer to the [Digital NEST AI Policy](TODO) for the current list of approved and prohibited AI tools. If a tool is not on the approved list, **do not use it** for work-related tasks.
+
+---
+
+## What You CAN Share with AI
+
+These are safe to include in prompts and conversations with approved AI tools:
+
+- Public documentation and open-source code
+- Generic code patterns and syntax questions
+- Error messages **with secrets redacted**
+- Questions about programming concepts, frameworks, or best practices
+- Code snippets that contain no secrets, PII, or proprietary business logic
+
+---
+
+## What You MUST NOT Share with AI
+
+Never paste, type, or upload any of the following into an AI tool:
+
+- **API keys, tokens, or passwords** — not even "just to debug"
+- **Database credentials or connection strings**
+- **Customer PII** (names, emails, phone numbers, addresses)
+- **Proprietary business logic** (pricing algorithms, internal workflows, trade secrets)
+- **Contents of `.env` files**
+- **Internal URLs, IP addresses, or infrastructure details**
+- **Full configuration files** — they often contain secrets you might miss
+
+> **DO**: Strip all secrets and PII from code before pasting it into an AI tool.
+>
+> **DON'T**: Paste entire files without reviewing them first — you might miss a hardcoded key.
+
+> **DO**: Ask AI generic questions like "How do I connect to PostgreSQL with Node.js?"
+>
+> **DON'T**: Ask "Why can't I connect to postgres://admin:p4ssw0rd@prod.internal:5432/customers?"
+
+---
+
+## NO Database Access for AI
+
+This is a hard rule with no exceptions:
+
+**AI tools must never be given direct access to any database — development, staging, or production.**
+
+This means:
+
+- Do NOT paste database connection strings into AI prompts.
+- Do NOT use AI tools that request database credentials to "help you query."
+- Do NOT give AI plugins or extensions access to your database.
+- Do NOT share database schemas that contain real table/column names tied to customer data.
+
+If you need help writing a query, describe the schema in generic terms or use fake table names.
+
+---
+
+## Prompt Hygiene
+
+Before you send a prompt to any AI tool, review it:
+
+1. **Read through your code snippet.** Does it contain any hardcoded values, secrets, or PII?
+2. **Replace real values with placeholders.** Use `YOUR_API_KEY`, `user@example.com`, `localhost` instead of real values.
+3. **Don't paste entire config files.** Extract only the relevant section.
+4. **Don't paste entire codebases.** Share only the specific function or file you need help with.
+
+---
+
+## Code Review of AI-Generated Output
+
+AI-generated code is not automatically correct or safe. Treat it the same way you'd treat code from an untrusted source.
+
+> **DO**: Review every line of AI-generated code before committing it.
+>
+> **DON'T**: Copy-paste AI output directly into your project without reading it.
+
+> **DO**: Run and test AI-generated code — make sure it actually works.
+>
+> **DON'T**: Assume AI output is bug-free or follows our project's conventions.
+
+> **DO**: Put AI-generated code through the normal [Code Review process](/standards/code-reviews.md).
+>
+> **DON'T**: Merge AI-generated code without peer review because "the AI wrote it correctly."
+
+> **DO**: Understand what the code does before using it.
+>
+> **DON'T**: Use code you can't explain — if you can't explain it, you can't debug it.
+
+---
+
+## Quick Reference
+
+| Question | Answer |
+|---|---|
+| Can I ask AI how to use a framework? | **Yes** |
+| Can I paste my `.env` file to debug an issue? | **No** — redact secrets first |
+| Can I give an AI plugin my DB connection string? | **Never** |
+| Can I paste a code snippet that has no secrets? | **Yes** |
+| Can I paste customer data to help format it? | **No** |
+| Can I merge AI code without review? | **No** — normal review process applies |
+| Can I use an AI tool not on the approved list? | **No** — check the Digital NEST AI Policy |

--- a/security/data-protection.md
+++ b/security/data-protection.md
@@ -1,0 +1,102 @@
+# Data Protection Standards
+
+Protecting data is everyone's responsibility. Whether it's a customer's email address, an API key, or our proprietary code — if it's not public, it must be treated with care.
+
+---
+
+## Secrets and Credentials
+
+Credentials are the keys to our systems. Treat them like your house keys — you wouldn't leave them on a park bench.
+
+> **DO**: Store all secrets in environment variables (see [Secrets Management](secrets-management.md)).
+>
+> **DON'T**: Hardcode passwords, API keys, or tokens anywhere in your code.
+
+> **DO**: Use a password manager for shared team credentials.
+>
+> **DON'T**: Share secrets over Slack, email, or text messages.
+
+> **DO**: Use different credentials for development, staging, and production.
+>
+> **DON'T**: Use production credentials in your local development environment.
+
+---
+
+## Personally Identifiable Information (PII)
+
+PII is any data that can identify a real person: names, emails, phone numbers, addresses, IP addresses, etc.
+
+> **DO**: Minimize PII collection — only collect what you actually need.
+>
+> **DON'T**: Add extra form fields "just in case" we might need the data later.
+
+> **DO**: Keep PII out of logs and error messages.
+>
+> **DON'T**: Log full user objects or request bodies that contain personal data.
+
+> **DO**: Anonymize or redact PII in development and staging environments.
+>
+> **DON'T**: Copy production databases to local machines for testing.
+
+### Example — Logging
+
+```javascript
+// BAD — logs PII
+console.log('User login:', { email: user.email, password: user.password, ip: req.ip });
+
+// GOOD — logs only what's needed for debugging
+console.log('User login:', { userId: user.id, success: true });
+```
+
+---
+
+## Customer Data
+
+Production data belongs in production. Full stop.
+
+> **DO**: Use seed data or mock data for local development.
+>
+> **DON'T**: Download production database exports to your laptop.
+
+> **DO**: Use tools that generate realistic fake data (e.g., Faker.js).
+>
+> **DON'T**: "Borrow" real customer records for testing.
+
+> **DO**: Ensure test/staging environments use anonymized data if they need real-ish data.
+>
+> **DON'T**: Share customer data with anyone outside the team, including in screenshots or demos.
+
+---
+
+## Proprietary Code and Intellectual Property
+
+Our code and business logic are company assets. Protecting them is part of your job.
+
+> **DO**: Keep all project repositories private within the BizzNEST organization.
+>
+> **DON'T**: Make repositories public without explicit approval from leadership.
+
+> **DO**: Ask permission before using code from a project in a personal portfolio.
+>
+> **DON'T**: Post proprietary code snippets on Stack Overflow, public Gists, or forums.
+
+> **DO**: Be careful what you share on screen during screen recordings or streams.
+>
+> **DON'T**: Include internal URLs, dashboards, or credentials in screenshots shared externally.
+
+> **DO**: Remember that NDA agreements cover code, architecture, and business logic.
+>
+> **DON'T**: Discuss project internals in public Discord servers, forums, or social media.
+
+---
+
+## Quick Reference
+
+| Data Type | Can I... | Answer |
+|---|---|---|
+| API Keys | Commit to Git? | **Never** |
+| Customer emails | Put in logs? | **No** — use user IDs instead |
+| Production DB | Copy to my laptop? | **No** — use seed data |
+| Project code | Post on Stack Overflow? | **No** — keep it private |
+| Internal URLs | Share in screenshots? | **No** — redact them first |
+| Test credentials | Share over Slack? | **No** — use a password manager |

--- a/security/incident-report-example.md
+++ b/security/incident-report-example.md
@@ -1,0 +1,131 @@
+# Incident Report: Data Leak — Example
+
+> **Note**: This is a fictional example to show BizzNEST interns what a completed incident report looks like. The names, dates, and details are all made up. Use the [Incident Report Template](incident-report-template.md) for real incidents.
+
+---
+
+## Report Details
+
+| Field | Value |
+|---|---|
+| **Report Date** | 2026-03-15 |
+| **Reported By** | Jamie Santos |
+| **Incident Date** | 2026-03-14 (when the commit was pushed) |
+| **Discovery Date** | 2026-03-15 (next morning during code review) |
+| **Severity** | High |
+| **Status** | Resolved |
+
+---
+
+## Summary
+
+A Firebase API key and database URL were accidentally committed to the `main` branch of the client portal repository. The commit was pushed to the public-facing GitHub repo and was visible for approximately 14 hours before being discovered during a code review the next morning.
+
+---
+
+## Timeline
+
+| Time | Event |
+|---|---|
+| 2026-03-14 5:45 PM | Jamie pushed a commit that included a hardcoded Firebase config object with the API key and database URL in `src/config.js` |
+| 2026-03-14 5:46 PM | Commit was merged to `main` via auto-merge (PR had prior approval) |
+| 2026-03-15 8:10 AM | Alex noticed the exposed key during a routine code review |
+| 2026-03-15 8:15 AM | Alex notified Jamie and the team lead via Slack DM |
+| 2026-03-15 8:22 AM | Jamie revoked the old Firebase API key in the Firebase console |
+| 2026-03-15 8:30 AM | Jamie generated a new API key and updated the environment variables on the hosting platform |
+| 2026-03-15 8:35 AM | Jamie pushed a new commit removing the hardcoded config and replacing it with `process.env` references |
+| 2026-03-15 9:00 AM | Team lead confirmed containment and notified BizzNEST leadership |
+| 2026-03-15 3:00 PM | Post-mortem meeting held with the team |
+
+---
+
+## What Was Leaked
+
+- [x] API keys or tokens
+- [ ] Database credentials
+- [ ] Customer PII (names, emails, phone numbers, etc.)
+- [x] Internal URLs or IP addresses
+- [ ] Source code or proprietary business logic
+- [ ] .env file contents
+- [ ] Other
+
+Specifically: Firebase API key (`AIzaSy...`) and Firebase Realtime Database URL (`https://project-name.firebaseio.com`).
+
+---
+
+## How It Happened
+
+Jamie was debugging a connection issue with Firebase and temporarily hardcoded the config values directly in `src/config.js` to isolate the problem. After fixing the bug, Jamie forgot to move the values back to the `.env` file before committing. The PR had already been approved earlier in the day for a different change, so the auto-merge went through without a second review of the new commit.
+
+---
+
+## Who / What Was Affected
+
+- **Systems affected**: Client portal Firebase project (database, authentication, storage)
+- **Data scope**: The API key could have been used to read/write to the Firebase Realtime Database. No evidence of unauthorized access was found in Firebase audit logs.
+- **External exposure**: The key was visible on the public GitHub repo for approximately 14 hours. GitHub secret scanning did not flag it because it was a Firebase key (not in their default patterns at the time).
+
+---
+
+## Containment Actions Taken
+
+1. Revoked the exposed Firebase API key in the Firebase console
+2. Generated a new API key with the same restrictions
+3. Updated the environment variables on the hosting platform (Vercel) with the new key
+4. Pushed a commit removing the hardcoded values from `src/config.js`
+5. Checked Firebase audit logs for any unauthorized reads or writes during the exposure window — none found
+6. Verified the application was working correctly with the new key
+
+---
+
+## Notification Chain
+
+| Who | When Notified | How |
+|---|---|---|
+| Team Lead (Maria) | 2026-03-15 8:15 AM | Slack DM |
+| BizzNEST Leadership | 2026-03-15 9:00 AM | Email from Maria |
+| Digital NEST IT | Not notified | No customer data was exposed; leadership determined IT notification was not required |
+| Affected Users | Not notified | No evidence of unauthorized access; no user data was compromised |
+
+---
+
+## Post-Mortem
+
+### Root Cause
+
+Two process gaps combined to cause this incident:
+
+1. **No pre-commit hook** was installed to scan for secrets before commits. If `git-secrets` had been set up, the commit would have been blocked.
+2. **Auto-merge after prior approval** meant a new commit bypassed review. The PR was approved for an earlier change, and the new commit with the hardcoded key went through without fresh eyes.
+
+### What Went Well
+
+- The leak was discovered within 14 hours during a routine code review
+- The API key was revoked within 7 minutes of discovery
+- Firebase audit logs confirmed no unauthorized access occurred
+- The team responded calmly and followed the incident response process
+
+### What Went Wrong
+
+- No pre-commit secrets scanning was in place
+- Hardcoding secrets "temporarily" for debugging — there's no such thing as temporary in Git
+- Auto-merge allowed a new commit through without re-review
+- The `.env.example` file didn't clearly list the Firebase config variables, making it less obvious they should come from environment variables
+
+### Action Items
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Install `git-secrets` on all active BizzNEST repos | Alex | 2026-03-22 | Complete |
+| Add Firebase key patterns to `git-secrets` config | Alex | 2026-03-22 | Complete |
+| Disable auto-merge on all repos — require re-approval after new commits | Maria | 2026-03-19 | Complete |
+| Update `.env.example` in client portal to include all Firebase variables | Jamie | 2026-03-17 | Complete |
+| Add "never hardcode secrets for debugging" to security onboarding docs | Maria | 2026-03-29 | Pending |
+
+---
+
+## Lessons Learned
+
+1. **There's no such thing as "temporary" in Git.** If you hardcode a secret, even for 5 minutes, assume it will end up in a commit. Use environment variables from the start — even when debugging.
+2. **Pre-commit hooks are a safety net, not a luxury.** `git-secrets` would have caught this before it ever left the developer's machine. Install it on every repo.
+3. **Auto-merge is risky.** A PR approved for one change shouldn't automatically merge future commits. Require fresh approval after every new push.

--- a/security/incident-report-template.md
+++ b/security/incident-report-template.md
@@ -1,0 +1,120 @@
+# Incident Report: Data Leak
+
+> **Instructions**: Copy this template when a data leak occurs. Fill in every section honestly and completely. This report is internal and confidential — do not share outside of BizzNEST leadership without approval. Refer to the [Incident Response guide](incident-response.md) for the full response process.
+
+---
+
+## Report Details
+
+| Field | Value |
+|---|---|
+| **Report Date** | YYYY-MM-DD |
+| **Reported By** | Your name |
+| **Incident Date** | When the leak was introduced (if known) |
+| **Discovery Date** | When the leak was discovered |
+| **Severity** | Critical / High / Medium / Low |
+| **Status** | Open / Contained / Resolved |
+
+---
+
+## Summary
+
+_Write 2–3 sentences describing what happened in plain language. What data was leaked, how, and where._
+
+---
+
+## Timeline
+
+| Time | Event |
+|---|---|
+| YYYY-MM-DD HH:MM | _What happened_ |
+| YYYY-MM-DD HH:MM | _What happened next_ |
+| YYYY-MM-DD HH:MM | _When it was discovered_ |
+| YYYY-MM-DD HH:MM | _Containment actions taken_ |
+| YYYY-MM-DD HH:MM | _Resolution confirmed_ |
+
+---
+
+## What Was Leaked
+
+_Be specific. List the exact data that was exposed._
+
+- [ ] API keys or tokens
+- [ ] Database credentials
+- [ ] Customer PII (names, emails, phone numbers, etc.)
+- [ ] Internal URLs or IP addresses
+- [ ] Source code or proprietary business logic
+- [ ] .env file contents
+- [ ] Other: _______________
+
+---
+
+## How It Happened
+
+_Describe the root cause. How did the data end up where it shouldn't be? Be honest — this is blameless._
+
+---
+
+## Who / What Was Affected
+
+- **Systems affected**: _List services, repos, databases, or environments impacted_
+- **Data scope**: _How many records, users, or keys were exposed?_
+- **External exposure**: _Was the data visible to the public internet? For how long?_
+
+---
+
+## Containment Actions Taken
+
+_List every action taken to stop the leak, in the order they were performed._
+
+1. _e.g., Revoked the leaked API key in the provider dashboard_
+2. _e.g., Rotated the credential and updated environment variables_
+3. _e.g., Notified team lead_
+4. ...
+
+---
+
+## Notification Chain
+
+| Who | When Notified | How |
+|---|---|---|
+| Team Lead | YYYY-MM-DD HH:MM | _Slack DM / Call / In person_ |
+| BizzNEST Leadership | YYYY-MM-DD HH:MM | _How_ |
+| Digital NEST IT | YYYY-MM-DD HH:MM | _How_ |
+| Affected Users (if applicable) | YYYY-MM-DD HH:MM | _How_ |
+
+---
+
+## Post-Mortem
+
+### Root Cause
+
+_What systemic issue allowed this to happen? Go deeper than "someone made a mistake." Was there a missing safeguard, unclear process, or tooling gap?_
+
+### What Went Well
+
+- _e.g., Leak was discovered within 30 minutes_
+- _e.g., Key was revoked immediately_
+
+### What Went Wrong
+
+- _e.g., No pre-commit hook to catch secrets_
+- _e.g., Production credentials were stored in a shared document_
+
+### Action Items
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| _e.g., Install git-secrets on all team repos_ | _Name_ | _YYYY-MM-DD_ | Pending |
+| _e.g., Move shared credentials to password manager_ | _Name_ | _YYYY-MM-DD_ | Pending |
+| _e.g., Add .env to .gitignore in project template_ | _Name_ | _YYYY-MM-DD_ | Pending |
+
+---
+
+## Lessons Learned
+
+_Write 1–3 key takeaways that the team should remember. These may be added to our security documentation._
+
+1. _..._
+2. _..._
+3. _..._

--- a/security/incident-response.md
+++ b/security/incident-response.md
@@ -83,6 +83,8 @@ Within 48 hours of containment, the team conducts a blameless post-mortem:
 - **Honest** — we document exactly what happened, even if it's embarrassing.
 - **Actionable** — every post-mortem must produce at least one concrete preventive measure.
 
+Use the [Incident Report Template](incident-report-template.md) to document the incident. See the [Incident Report Example](incident-report-example.md) for a completed sample.
+
 ### Post-Mortem Template
 
 1. **Summary** — One paragraph describing the incident.

--- a/security/incident-response.md
+++ b/security/incident-response.md
@@ -1,0 +1,118 @@
+# Incident Response
+
+Security incidents happen — what matters is how quickly and effectively you respond. If you think something might be an incident, treat it as one. It's always better to over-report than to stay quiet and let things get worse.
+
+---
+
+## What Counts as an Incident
+
+Report immediately if you observe any of the following:
+
+- **Leaked credentials** — a secret was committed to Git, shared publicly, or sent to an unauthorized person
+- **Unauthorized access** — someone accessed a system, repo, or account they shouldn't have
+- **Data breach** — customer data was exposed, downloaded, or shared outside the organization
+- **Exposed PII** — personal information appeared in logs, error messages, public pages, or screenshots
+- **Compromised account** — your GitHub, email, or any work account was accessed by someone else
+- **Suspicious activity** — unexpected changes to code, infrastructure, or permissions that nobody on the team made
+
+---
+
+## Immediate Steps (Containment)
+
+When you discover an incident, act fast. Do these in order:
+
+### 1. Contain the Damage
+
+- **Leaked credential?** Rotate/revoke it immediately. Don't wait for approval — revoke first, ask questions later.
+- **Compromised account?** Change the password and enable 2FA right now.
+- **Exposed data?** Take the affected service offline if you can, or remove the exposure.
+
+### 2. Do NOT Destroy Evidence
+
+> **DO**: Leave logs, commits, and messages intact for investigation.
+>
+> **DON'T**: Delete commits, clear logs, or edit chat messages to "hide" the incident.
+
+> **DO**: Take screenshots of what you see.
+>
+> **DON'T**: Force-push to remove evidence from Git history.
+
+### 3. Notify Your Team Lead
+
+Tell your team lead immediately — in person, over a call, or via direct message. Do not wait until standup or your next meeting.
+
+Include:
+- What happened (brief description)
+- When you discovered it
+- What you've already done to contain it
+- What systems or data are affected
+
+---
+
+## Notification Chain
+
+1. **You** → Tell your **Team Lead** immediately
+2. **Team Lead** → Escalates to **BizzNEST Leadership / Digital NEST IT**
+3. **Leadership** → Determines if external notification is needed (users, partners, legal)
+
+You are responsible for step 1. Do not skip it. Do not decide on your own that "it's not a big deal."
+
+---
+
+## Documentation
+
+As soon as the immediate crisis is handled, write down what you know:
+
+- **What happened?** (Describe the incident in plain language)
+- **When did it happen?** (When was it introduced? When was it discovered?)
+- **What was the impact?** (What data/systems were affected? How many users?)
+- **What did you do?** (Steps you took to contain it)
+- **What's still at risk?** (Anything that hasn't been resolved yet)
+
+Write this in a private document or issue — not in a public channel.
+
+---
+
+## Post-Mortem Process
+
+Within 48 hours of containment, the team conducts a blameless post-mortem:
+
+### Rules
+
+- **Blameless** — we focus on systems and processes, not individuals. Nobody gets punished for reporting an incident.
+- **Honest** — we document exactly what happened, even if it's embarrassing.
+- **Actionable** — every post-mortem must produce at least one concrete preventive measure.
+
+### Post-Mortem Template
+
+1. **Summary** — One paragraph describing the incident.
+2. **Timeline** — Chronological list of events (when introduced, when discovered, when contained, when resolved).
+3. **Root Cause** — What systemic issue allowed this to happen?
+4. **Impact** — What was the blast radius? Users affected? Data exposed?
+5. **What Went Well** — What helped us catch and contain this?
+6. **What Went Wrong** — What made this possible or delayed our response?
+7. **Action Items** — Specific, assigned tasks to prevent recurrence.
+
+---
+
+## DOs and DON'Ts
+
+> **DO**: Report incidents immediately, even if you caused them.
+>
+> **DON'T**: Try to fix it quietly by yourself and hope nobody notices.
+
+> **DO**: Revoke compromised credentials first, then investigate.
+>
+> **DON'T**: Spend time investigating while the credential is still active.
+
+> **DO**: Preserve all evidence (logs, screenshots, commits).
+>
+> **DON'T**: Delete or modify evidence to cover tracks.
+
+> **DO**: Treat post-mortems as learning opportunities.
+>
+> **DON'T**: Blame individuals — blame the process that allowed the mistake.
+
+> **DO**: Follow up on action items from post-mortems.
+>
+> **DON'T**: Write action items and then forget about them.

--- a/security/secrets-management.md
+++ b/security/secrets-management.md
@@ -1,0 +1,113 @@
+# Secrets Management
+
+## The Golden Rule
+
+**Never commit secrets to version control. Period.**
+
+If a secret ends up in a Git commit — even if you delete it afterward — it lives in the Git history forever. Assume it has been compromised.
+
+---
+
+## What Counts as a Secret
+
+- API keys and tokens (Stripe, Firebase, AWS, etc.)
+- Database connection strings and passwords
+- OAuth client secrets
+- Private keys and certificates
+- Internal URLs and IP addresses
+- `.env` file contents
+
+---
+
+## Using .env Files
+
+`.env` files are how we manage secrets locally. Follow these rules:
+
+> **DO**: Add `.env` and `.env.*` to your `.gitignore` file.
+>
+> **DON'T**: Ever commit a `.env` file, even "temporarily."
+
+> **DO**: Create a `.env.example` file with placeholder values that shows what variables are needed.
+>
+> **DON'T**: Put real values in `.env.example`.
+
+### Example .env.example
+
+```
+# Database
+DB_HOST=localhost
+DB_USER=your_username_here
+DB_PASS=your_password_here
+
+# API Keys
+STRIPE_SECRET_KEY=sk_test_xxxxxxxxxxxx
+FIREBASE_API_KEY=your_key_here
+```
+
+---
+
+## Key Rotation
+
+Secrets should not live forever. Rotate them regularly and immediately if compromised.
+
+> **DO**: Use different keys for development, staging, and production.
+>
+> **DON'T**: Use the same API key across all environments.
+
+> **DO**: Rotate keys on a regular schedule (quarterly at minimum).
+>
+> **DON'T**: Keep using the same key for years because "it still works."
+
+> **DO**: Revoke old keys immediately after rotation.
+>
+> **DON'T**: Leave old keys active "just in case."
+
+---
+
+## Pre-Commit Protection
+
+Set up tools that prevent you from accidentally committing secrets.
+
+### Recommended: git-secrets
+
+```bash
+# Install
+brew install git-secrets
+
+# Set up in your repo
+git secrets --install
+git secrets --register-aws  # blocks AWS keys automatically
+```
+
+You can also add custom patterns for your project's secrets (e.g., internal API key prefixes).
+
+---
+
+## What To Do If You Commit a Secret
+
+This is critical — **deleting the commit is NOT enough.** The secret is in your Git history and may have already been pushed.
+
+### Immediate Steps
+
+1. **Rotate the secret immediately.** Generate a new key/password and update it wherever it's used.
+2. **Revoke the old secret.** Deactivate it in the provider's dashboard (AWS, Stripe, Firebase, etc.).
+3. **Tell your team lead.** They need to know so they can assess impact.
+4. **Do NOT force-push to "hide" it.** Others may have already pulled the commit.
+
+### After Containment
+
+5. Remove the secret from the code and commit the fix.
+6. If the repo is public, assume the secret was scraped by bots within seconds.
+7. Follow the [Incident Response](incident-response.md) process if the leaked secret had access to production data.
+
+---
+
+## Quick Reference
+
+| Situation | Action |
+|---|---|
+| Need to use a secret in code | Put it in `.env`, access via `process.env.SECRET_NAME` |
+| Setting up a new project | Create `.gitignore` with `.env*` BEFORE your first commit |
+| Reviewing a PR | Check that no secrets are hardcoded or visible in diffs |
+| Deploying to production | Use the hosting platform's environment variable settings |
+| Accidentally committed a secret | Rotate immediately, then notify your lead |

--- a/security/secure-development.md
+++ b/security/secure-development.md
@@ -1,0 +1,96 @@
+# Secure Development Practices
+
+Writing secure code is not just for security experts — it's part of every developer's job. These rules help you avoid introducing vulnerabilities into our projects.
+
+---
+
+## Input Validation
+
+Never trust data that comes from outside your application. This includes form inputs, URL parameters, API request bodies, and anything a user can control.
+
+> **DO**: Use parameterized queries for all database calls.
+>
+> **DON'T**: Concatenate user input directly into SQL strings.
+
+> **DO**: Validate input on the server side, even if you also validate on the client.
+>
+> **DON'T**: Rely only on front-end validation — it can be bypassed.
+
+> **DO**: Sanitize and escape output to prevent XSS (cross-site scripting).
+>
+> **DON'T**: Render raw user input directly into HTML.
+
+### Example — SQL Injection
+
+```javascript
+// BAD — vulnerable to SQL injection
+const query = `SELECT * FROM users WHERE email = '${userInput}'`;
+
+// GOOD — parameterized query
+const query = `SELECT * FROM users WHERE email = $1`;
+const result = await db.query(query, [userInput]);
+```
+
+---
+
+## Dependency Management
+
+Every package you install is code you didn't write and didn't review. Treat dependencies as a potential risk.
+
+> **DO**: Run `npm audit` before every pull request and fix critical/high vulnerabilities.
+>
+> **DON'T**: Ignore audit warnings or use `--force` to skip them without understanding why.
+
+> **DO**: Remove packages you're no longer using.
+>
+> **DON'T**: Leave unused dependencies in `package.json` — they increase your attack surface.
+
+> **DO**: Pin dependency versions or use lock files (`package-lock.json`).
+>
+> **DON'T**: Use `*` or overly broad version ranges in production.
+
+---
+
+## HTTPS Everywhere
+
+All communication between clients and servers must be encrypted.
+
+> **DO**: Use HTTPS for every endpoint, API call, and external resource.
+>
+> **DON'T**: Load scripts, images, or APIs over plain HTTP (mixed content).
+
+> **DO**: Redirect HTTP requests to HTTPS.
+>
+> **DON'T**: Disable SSL certificate verification in your code, even in development.
+
+---
+
+## Least Privilege
+
+Only request the minimum permissions your code needs to function. This limits the damage if something goes wrong.
+
+> **DO**: Create database users with only the permissions they need (e.g., read-only for reporting).
+>
+> **DON'T**: Use a root or admin database account in your application code.
+
+> **DO**: Request only the OAuth scopes your app actually uses.
+>
+> **DON'T**: Request broad permissions "just in case" you might need them later.
+
+> **DO**: Run services with the minimum system permissions required.
+>
+> **DON'T**: Run application processes as root.
+
+---
+
+## Error Handling
+
+Errors can leak sensitive information if you're not careful.
+
+> **DO**: Return generic error messages to users (e.g., "Something went wrong").
+>
+> **DON'T**: Expose stack traces, file paths, database names, or internal IPs in error responses.
+
+> **DO**: Log detailed errors server-side for debugging.
+>
+> **DON'T**: Include sensitive data (passwords, tokens, PII) in log messages.

--- a/standards/bug-reporting.md
+++ b/standards/bug-reporting.md
@@ -1,0 +1,42 @@
+# Bug Reporting at BizzNEST
+
+## When to File a Bug
+
+File a bug report when you encounter:
+
+- **Unexpected behavior** — something works differently than it should based on the requirements.
+- **Visual glitches** — layout breaks, overlapping elements, or styling issues.
+- **Crashes or errors** — the app crashes, shows error screens, or throws unhandled exceptions.
+- **Regressions** — something that was working before is now broken after a recent change.
+
+If you're unsure whether something is a bug, ask in your team channel first.
+
+## How to File a Bug Report
+
+1. Go to the project's GitHub repository.
+2. Click the **Issues** tab and then **New issue**.
+3. Select the **Bug Report** template.
+4. Fill out **every section** of the template — don't skip fields.
+5. Add the `bug` label to your issue.
+6. Assign the issue to yourself if you plan to fix it, or leave it unassigned for your lead to triage.
+7. Add the issue to the project board in the **Backlog** column.
+
+Our bug report template is located at [`.github/ISSUE_TEMPLATE/bug_report.md`](/.github/ISSUE_TEMPLATE/bug_report.md).
+
+## Writing Good Reproduction Steps
+
+The most important part of a bug report is **how to reproduce it**. Follow these rules:
+
+- **Number every step.** Use a numbered list, not a paragraph.
+- **Be specific.** Say "Click the Submit button on the Contact form" not "Click submit."
+- **Include the starting point.** Where does the user begin? (e.g., "Start on the home page, logged in as an admin.")
+- **State expected vs. actual.** What should happen? What actually happens?
+- **Attach screenshots or screen recordings.** A picture is worth a thousand words.
+- **Include environment info.** Browser, OS, screen size — anything relevant.
+
+## Bug Lifecycle
+
+1. **Open** — Bug is reported and sitting in the Backlog.
+2. **In Progress** — Someone is actively working on a fix. Create a branch following the naming convention: `<initials>-<issue#>-<description>` (e.g., `ar-15-fix-login-crash`).
+3. **In Review** — A fix has been submitted as a Pull Request and is waiting for code review.
+4. **Closed** — The fix has been reviewed, approved, merged, and verified.

--- a/standards/code-reviews.md
+++ b/standards/code-reviews.md
@@ -1,0 +1,42 @@
+# Code Review at BizzNEST
+
+## Why Code Reviews Matter
+
+Code reviews help us catch bugs before they reach production, share knowledge across the team, and keep our codebase clean and consistent. Every Pull Request goes through a review — no exceptions.
+
+## Process
+
+1. **Open a Pull Request.** Follow the [PR template](/.github/pull_request_template.md) and fill out every section.
+2. **Assign at least two reviewers.** One reviewer must be a team lead or admin.
+3. **Reviewers respond within 24 hours.** If you're assigned as a reviewer, make time to review promptly.
+4. **Address all feedback.** Make the requested changes, push new commits, and re-request a review.
+5. **Merge after approval.** Once you have the required approvals, merge your branch following the [branching guidelines](/standards/branching.md).
+
+## What Reviewers Look For
+
+Use this checklist when reviewing someone's code:
+
+- [ ] Code does what the linked issue describes
+- [ ] Variable and function names are clear and descriptive
+- [ ] No `console.log` statements left in the code
+- [ ] No hardcoded values that should be in environment variables
+- [ ] Follows the project's existing code style and patterns
+- [ ] Commit messages follow the [commit conventions](/standards/commits.md)
+- [ ] Branch name follows the [branching naming convention](/standards/branching.md)
+- [ ] No commented-out code left behind
+- [ ] Changes are tested and working
+
+## Giving Good Feedback
+
+- Be specific — say **what** needs to change and **why**.
+- Suggest alternatives instead of just saying "this is wrong."
+- Use GitHub's **suggestion** feature to propose exact code changes.
+- Keep it constructive and professional.
+- Prefix optional suggestions with "nit:" so the author knows it's not blocking.
+
+## Receiving Feedback
+
+- Don't take feedback personally — reviews are about the code, not you.
+- Ask clarifying questions if you don't understand a comment.
+- Treat every review as a learning opportunity.
+- Thank your reviewers — they're spending their time to help improve your work.

--- a/standards/project-setup.md
+++ b/standards/project-setup.md
@@ -1,0 +1,44 @@
+# Setting Up GitHub Projects at BizzNEST
+
+## Overview
+
+GitHub Projects is how we track tasks, bugs, and progress at BizzNEST. Every project should have a Project Board that your team lead and teammates can view to see what you're working on, what's blocked, and what's done.
+
+## Creating a Project Board
+
+1. Go to the [BizzNEST GitHub Organization](https://github.com/BizzNEST).
+2. Click on the **Projects** tab.
+3. Click **New project**.
+4. Choose the **Board** view (Kanban-style).
+5. Name it to match your project (e.g., `Project Name - Sprint Board`).
+
+## Recommended Columns
+
+Set up these columns on your board:
+
+| Column | What Goes Here |
+|---|---|
+| **Backlog** | Tasks that are planned but not started yet |
+| **In Progress** | Tasks you are actively working on |
+| **In Review** | Tasks with an open Pull Request waiting for review |
+| **Done** | Completed and merged tasks |
+
+## Adding Issues to the Board
+
+- Every task should start as a **GitHub Issue** before it goes on the board.
+- When creating an issue, use the appropriate issue template (feature request, bug report, or epic).
+- Add the issue to your project board from the issue sidebar under **Projects**.
+- Assign the issue to yourself when you start working on it.
+
+## Using the Board During Sprints
+
+- **Update your cards daily.** Move them to the correct column as your work progresses.
+- When you open a Pull Request, move the card to **In Review**.
+- When your PR is merged, move the card to **Done** and close the issue.
+- Your team lead will check the board during standups and weekly meetings — keep it accurate.
+
+## Tips
+
+- Don't let cards pile up in **In Progress** — focus on finishing tasks before starting new ones.
+- Link your Pull Requests to issues using keywords like `Closes #12` in the PR description.
+- If you're blocked, add a comment to the issue explaining why and mention your lead.


### PR DESCRIPTION
## Summary

- Added 3 starter scaffold documents to fix broken links in the README (`project-setup.md`, `code-reviews.md`, `bug-reporting.md`)
- Created a new `security/` folder with 5 security guides targeting junior devs/interns:
  - **Secure Development** — input validation, dependency management, HTTPS, least privilege
  - **Data Protection** — PII handling, customer data, proprietary code/IP protection
  - **AI Usage Policy** — approved tools (references Digital NEST AI Policy), what data can/can't be shared, no DB access for AI, prompt hygiene
  - **Secrets Management** — .env files, key rotation, git-secrets, incident escalation if leaked
  - **Incident Response** — containment steps, notification chain, blameless post-mortem process
- Updated main README.md TOC with a new Security section

## Notes for Reviewers

- The AI Usage Policy references the Digital NEST AI Policy with a `TODO` placeholder link — needs the actual URL filled in
- `code-reviews.md` uses a `## Process` heading to match the existing `#process` anchor link in the README
- All security docs use a DO/DON'T format for quick scanning by junior developers

## Test plan

- [ ] Verify all previously broken links in README now resolve (`project-setup.md`, `code-reviews.md`, `bug-reporting.md`)
- [ ] Verify `code-reviews.md#process` anchor link works
- [ ] Verify all security section links in README resolve to existing files
- [ ] Verify `security/README.md` TOC links all resolve
- [ ] Review tone/depth for junior audience

🤖 Generated with [Claude Code](https://claude.com/claude-code)