### PR TITLE
docs: add Docsify site with dark theme and sidebar navigation

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,0 +1,30 @@
+- [Home](/)
+
+- **Standards**
+  - [Contributing](standards/contributing.md)
+  - [Branching](standards/branching.md)
+  - [Commit Messages](standards/commits.md)
+  - [Code Reviews](standards/code-reviews.md)
+  - [Bug Reporting](standards/bug-reporting.md)
+  - [Project Setup](standards/project-setup.md)
+  - [GitHub Repositories](standards/github-projects.md)
+  - [README Guidelines](standards/readme-guidelines.md)
+  - [CSS Naming (BEM)](standards/css-naming-bestPractice.md)
+  - [Tech Stack Comparison](standards/tech-stack-comp.md)
+
+- **Best Practices**
+  - [Accessibility](best-practices/accessibility.md)
+  - [Local & WPE Deployment](best-practices/local-and-wpe-deployment-best-practices.md)
+  - [Child Themes, CPTs & ACFs](best-practices/wp-acf-cpt-child-theme.md)
+  - [SFTP into WPE](best-practices/wpe-sftp.md)
+  - [Adding Users (phpMyAdmin/WP)](best-practices/adding-users-phpadmin-wpdashboard.md)
+
+- **Security**
+  - [Overview](security/README.md)
+  - [Secure Development](security/secure-development.md)
+  - [Data Protection](security/data-protection.md)
+  - [Secrets Management](security/secrets-management.md)
+  - [AI Usage Policy](security/ai-usage-policy.md)
+  - [Incident Response](security/incident-response.md)
+  - [Incident Report Template](security/incident-report-template.md)
+  - [Incident Report Example](security/incident-report-example.md)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>BizzNEST Standards & Practices</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css">
+  <style>
+    :root {
+      --theme-color: #6ea8fe;
+      --base-background-color: #0d1117;
+      --base-color: #e6edf3;
+
+      --sidebar-background: #161b22;
+      --sidebar-color: #c9d1d9;
+      --sidebar-name-color: #6ea8fe;
+      --sidebar-name-font-size: 1.4rem;
+      --sidebar-name-font-weight: 700;
+      --sidebar-nav-link-color: #c9d1d9;
+      --sidebar-nav-link-color--active: #6ea8fe;
+      --sidebar-nav-link-font-weight--active: 600;
+      --sidebar-nav-strong-color: #8b949e;
+      --sidebar-nav-strong-font-size: 0.85rem;
+      --sidebar-nav-strong-font-weight: 600;
+      --sidebar-nav-strong-text-transform: uppercase;
+      --sidebar-nav-strong-margin: 1.5em 0 0.5em 0;
+      --sidebar-border-color: #30363d;
+      --sidebar-width: 300px;
+
+      --content-max-width: 860px;
+
+      --heading-color: #e6edf3;
+      --heading-h1-font-size: 2rem;
+      --heading-h2-font-size: 1.5rem;
+      --heading-h2-border-color: #30363d;
+
+      --link-color: #6ea8fe;
+      --link-color--hover: #93c5fd;
+
+      --code-inline-background: #1c2128;
+      --code-inline-color: #e06c75;
+      --code-inline-border-radius: 4px;
+      --code-inline-padding: 2px 6px;
+      --code-block-background: #161b22;
+      --code-block-border-radius: 8px;
+      --code-block-padding: 1.2em;
+
+      --blockquote-border-color: #6ea8fe;
+      --blockquote-background: #161b22;
+      --blockquote-color: #8b949e;
+
+      --table-head-background: #161b22;
+      --table-head-color: #e6edf3;
+      --table-body-border-color: #30363d;
+      --table-row-even-background: #0d1117;
+      --table-row-odd-background: #161b22;
+
+      --search-background: #0d1117;
+      --search-color: #e6edf3;
+      --search-border-color: #30363d;
+      --search-result-heading-color: #6ea8fe;
+
+      --notice-tip-border-color: #6ea8fe;
+      --notice-important-border-color: #f0883e;
+
+      --cover-background-color: #0d1117;
+    }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .sidebar-nav li a:hover {
+      color: #6ea8fe;
+    }
+
+    .markdown-section h1,
+    .markdown-section h2 {
+      letter-spacing: -0.02em;
+    }
+
+    .markdown-section h2 {
+      border-bottom: 1px solid #30363d;
+      padding-bottom: 0.4em;
+    }
+
+    .markdown-section a {
+      text-decoration: none;
+      border-bottom: 1px solid transparent;
+      transition: border-color 0.2s;
+    }
+
+    .markdown-section a:hover {
+      border-bottom-color: #6ea8fe;
+    }
+
+    .markdown-section code {
+      font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
+      font-size: 0.875em;
+    }
+
+    .markdown-section table {
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    ::-webkit-scrollbar {
+      width: 8px;
+    }
+
+    ::-webkit-scrollbar-track {
+      background: #0d1117;
+    }
+
+    ::-webkit-scrollbar-thumb {
+      background: #30363d;
+      border-radius: 4px;
+    }
+
+    ::-webkit-scrollbar-thumb:hover {
+      background: #484f58;
+    }
+
+    .search .input-wrap {
+      border-radius: 8px !important;
+    }
+
+    .search input {
+      border-radius: 8px !important;
+      background: #0d1117 !important;
+      color: #e6edf3 !important;
+    }
+
+    .app-name-link {
+      letter-spacing: -0.02em;
+    }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      name: 'BizzNEST',
+      loadSidebar: true,
+      subMaxLevel: 2,
+      search: {
+        placeholder: 'Search...',
+        noData: 'No results',
+        depth: 3,
+      },
+      auto2top: true,
+      copyCode: {
+        buttonText: 'Copy',
+        successText: 'Copied',
+      },
+    }
+  </script>
+  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/docsify-copy-code@2/dist/docsify-copy-code.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-javascript.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-css.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-json.min.js"></script>
+</body>
+</html>

--- a/security/data-protection.md
+++ b/security/data-protection.md
@@ -87,16 +87,3 @@ Our code and business logic are company assets. Protecting them is part of your 
 > **DO**: Remember that NDA agreements cover code, architecture, and business logic.
 >
 > **DON'T**: Discuss project internals in public Discord servers, forums, or social media.
-
----
-
-## Quick Reference
-
-| Data Type | Can I... | Answer |
-|---|---|---|
-| API Keys | Commit to Git? | **Never** |
-| Customer emails | Put in logs? | **No** — use user IDs instead |
-| Production DB | Copy to my laptop? | **No** — use seed data |
-| Project code | Post on Stack Overflow? | **No** — keep it private |
-| Internal URLs | Share in screenshots? | **No** — redact them first |
-| Test credentials | Share over Slack? | **No** — use a password manager |


### PR DESCRIPTION
Set up Docsify to serve the Standards & Practices repo as a public documentation site. Includes dark theme (GitHub-style), Inter + JetBrains Mono fonts, full-text search, syntax highlighting, and copy-code buttons. Adds sidebar navigation covering all 23 docs across standards, best-practices, and security sections. Removes redundant Quick Reference table from data-protection.md.